### PR TITLE
Refactor installer code requesting certificates

### DIFF
--- a/install/certmonger/dogtag-ipa-ca-renew-agent-submit
+++ b/install/certmonger/dogtag-ipa-ca-renew-agent-submit
@@ -85,7 +85,7 @@ def ldap_connect():
     conn = None
     try:
         conn = ldap2(api)
-        conn.connect(ccache=os.environ['KRB5CCNAME'])
+        conn.connect(autobind=True)
         yield conn
     finally:
         if conn is not None and conn.isconnected():
@@ -484,11 +484,6 @@ def main():
     tmpdir = tempfile.mkdtemp(prefix="tmp-")
     certs.renewal_lock.acquire()
     try:
-        principal = str('host/%s@%s' % (api.env.host, api.env.realm))
-        ccache_filename = os.path.join(tmpdir, 'ccache')
-        os.environ['KRB5CCNAME'] = ccache_filename
-        ipautil.kinit_keytab(principal, paths.KRB5_KEYTAB, ccache_filename)
-
         profile = os.environ.get('CERTMONGER_CA_PROFILE')
         if profile:
             handler = handlers.get(profile, request_and_store_cert)

--- a/install/certmonger/dogtag-ipa-ca-renew-agent-submit
+++ b/install/certmonger/dogtag-ipa-ca-renew-agent-submit
@@ -171,7 +171,7 @@ def request_cert():
                   "Forwarding request to dogtag-ipa-renew-agent")
 
     path = paths.DOGTAG_IPA_RENEW_AGENT_SUBMIT
-    args = [path] + sys.argv[1:]
+    args = [path] + sys.argv[1:] + ['--submit-option', "requestor_name=IPA"]
     if os.environ.get('CERTMONGER_CA_PROFILE') == 'caCACert':
         args += ['-N', '-O', 'bypassCAnotafter=true']
     result = ipautil.run(args, raiseonerr=False, env=os.environ,

--- a/ipaserver/install/certs.py
+++ b/ipaserver/install/certs.py
@@ -344,18 +344,6 @@ class CertDB(object):
 
         return dercert
 
-    def create_signing_cert(self, nickname, hostname, other_certdb=None, subject=None):
-        cdb = other_certdb
-        if not cdb:
-            cdb = self
-        if subject is None:
-            subject=DN(('CN', hostname), self.subject_base)
-        self.request_cert(subject)
-        cdb.issue_signing_cert(self.certreq_fname, self.certder_fname)
-        self.import_cert(self.certder_fname, nickname)
-        os.unlink(self.certreq_fname)
-        os.unlink(self.certder_fname)
-
     def request_cert(
             self, subject, certtype="rsa", keysize="2048",
             san_dnsnames=None):

--- a/ipaserver/install/dogtaginstance.py
+++ b/ipaserver/install/dogtaginstance.py
@@ -127,7 +127,7 @@ class DogtagInstance(service.Service):
         self.admin_dn = DN(('uid', self.admin_user),
                            ('ou', 'people'), ('o', 'ipaca'))
         self.admin_groups = None
-        self.agent_db = tempfile.mkdtemp(prefix="tmp-")
+        self.agent_db = tempfile.mkdtemp(prefix="tmp-", dir=paths.VAR_LIB_IPA)
         self.subsystem = subsystem
         self.security_domain_name = "IPA"
         # replication parameters

--- a/ipatests/test_integration/tasks.py
+++ b/ipatests/test_integration/tasks.py
@@ -688,6 +688,7 @@ def uninstall_master(host, ignore_topology_disconnect=True,
                       paths.SYSCONFIG_PKI_TOMCAT_PKI_TOMCAT_DIR,
                       paths.VAR_LIB_PKI_TOMCAT_DIR,
                       paths.PKI_TOMCAT,
+                      paths.IPA_RENEWAL_LOCK,
                       paths.REPLICA_INFO_GPG_TEMPLATE % host.hostname],
                      raiseonerr=False)
     host.run_command("find /var/lib/sss/keytabs -name '*.keytab' | "


### PR DESCRIPTION
- Create a temporary certmonger CA helper to request the IPA RA agent cert,
  using the temp cert created during pkispawn. The cert request is now processed
  through certmonger, and the temp helper is removed once the agent cert is
  obtained.
- Modify the installer code creating HTTP and LDAP certificates to use
  certmonger's dogtag-ipa-ca-renew-agent with a specific installer profile.
- Modify ipa-replica-prepare code so that the replica certificates are
  requested through certmonger's dogtag-ipa-ca-renew-agent with a specific
  installer profile.
- Modify dogtag-ipa-ca-renew-agent so that it uses agent-submission for
  the installer profile.
- Clean-up for the integration tests: sometimes ipa renewal.lock is not
  released during ipa-server-uninstall. Make sure that the file is removed
  to allow future installations.

https://fedorahosted.org/freeipa/ticket/6433
